### PR TITLE
Add title attributes and other accessibility fixes for map controls

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -4,7 +4,7 @@
 
     <div class="container-fluid px-1 pt-7 pb-4 filter-buttons-container" :class="{ desktop: $vuetify.breakpoint.mdAndUp, 'sidebar-expanded': appState.factoryDetailsExpanded }" v-if="appState.isInitialPage">
       <display-setting-bottom-sheet />
-      <v-btn class="mx-2 mb-5 primary--text" v-for="button in filterButtonsData" :key="button.value" @click="onClickFilterButton(button.value)" rounded :class="{ 'v-btn--active': checkActive(button.value) }" color="white">
+      <v-btn class="mx-2 mb-5 primary--text" v-for="button in filterButtonsData" :key="button.value" @click="onClickFilterButton(button.value)" rounded :class="{ 'v-btn--active': checkActive(button.value) }" color="white" :name="button.text">
         <v-icon :color="button.color">mdi-map-marker</v-icon>
         {{ button.text }}
       </v-btn>
@@ -220,7 +220,8 @@ export default createComponent({
     const filterButtonsData = defaultFactoryDisplayStatuses.map(v => ({
       text: getDisplayStatusText(v),
       color: getDisplayStatusColor(v),
-      value: v
+      value: v,
+      name: v
     }))
 
     return {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -11,7 +11,7 @@
     </div>
 
     <div class="ol-fit-location ol-unselectable ol-control" @click="zoomToGeolocation" data-label="map-locate">
-      <button>
+      <button title="定位">
         <img src="/images/locate.svg" alt="locate">
       </button>
     </div>

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -475,7 +475,9 @@ export class OLMap {
       controls: [
         new Zoom({
           zoomInLabel: mapControlButtons.zoomIn,
-          zoomOutLabel: mapControlButtons.zoomOut
+          zoomOutLabel: mapControlButtons.zoomOut,
+          zoomInTipLabel: '放大',
+          zoomOutTipLabel: '縮小'
         }),
         new ScaleLine(),
         new Rotate(),

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -62,6 +62,8 @@ const makeMapButtons = () => {
   }).reduce((acc, [key, image]) => {
     const label = document.createElement('img')
     label.setAttribute('src', image)
+    label.setAttribute('alt',
+      key === 'zoomIn' ? '放大' : '縮小')
 
     return {
       ...acc,


### PR DESCRIPTION
1. Switch zoom control `title` attributes from default English to Mandarin. 
* Because most users are Mandarin speakers
* TEST: Hover mouse over zoom controls. Ensure proper text displays in popup.
2. Set the + and - zoom button images to have `src` attributes
* To ensure something displays if the image fails to load
* To improve accessibility
* TEST: Inspect the + and - images, ensure there is a `src` attribute with a value that makes sense
3. Add Title attribute to Location control
* To ensure a tooltip display
* To improve accessibility 
* TEST: Hover mouse over Location control, ensure tooltip appears
4. Add Name attributes to filter buttons
* To improve accessibility
* TEST: Inspect map factory filter buttons, ensure they have sensible `name` attributes

Addresses https://github.com/Disfactory/frontend/issues/84 and https://github.com/Disfactory/frontend/issues/77